### PR TITLE
ignore unreliable test test_check_category_list

### DIFF
--- a/tests/gear_page/test_gear_page.py
+++ b/tests/gear_page/test_gear_page.py
@@ -76,6 +76,7 @@ class TestGearPageCategory:
             category_list.remove(category_name)
             founded_categories.append(category_name)
 
+    @pytest.mark.skip(reason="the test is dependent on the order and fails in CI/CD")
     def test_check_category_list(self):
         """Additional step to verify the total list of categories after the previous test cases"""
 


### PR DESCRIPTION
test_check_category_list depends on other tests. CI/CD runs tests in a random order within the class which renders the test unreliable and unstable